### PR TITLE
Depend on django >= 1.6.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,8 @@ setup(
     long_description=open(os.path.join(os.path.dirname(__file__), 'README.md'), 'r').read(),
     py_modules=['pyzillow', 'pyzillowerrors', '__version__'],
     provides=['pyzillow'],
-    requires=['requests'],
-    install_requires=['requests >= 2.2.0'],
+    requires=['django', 'requests'],
+    install_requires=['django >= 1.6.4', 'requests >= 2.2.0'],
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Financial and Insurance Industry',


### PR DESCRIPTION
> from django.contrib.gis.geos.error import GEOSException

Package does not work without django installed. I listed the current version as the dependency.
