### PR TITLE
Add address and price attribute mapping to existing GetDeepSearchResults and GetUpdatedPropertyDetails APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ The following attributes are currently supported:
     - map_this_home_link
     - latitude
     - latitude
+    - street
+    - city
+    - state
+    - zipcode
     - coordinates
     - tax_year
     - tax_value
@@ -72,6 +76,7 @@ The following attributes are currently supported:
     - last_sold_date
     - last_sold_price_currency
     - last_sold_price
+    - price
 
 
 Usage of the GetUpdatedPropertyDetails API
@@ -95,6 +100,10 @@ The following attributes are currently supported:
     - photo_gallery
     - latitude
     - latitude
+    - street
+    - city
+    - state
+    - zipcode
     - coordinates
     - year_built
     - property_size
@@ -112,6 +121,7 @@ The following attributes are currently supported:
     - rooms
     - neighborhood
     - school_district
+    - price
 
 The following attributes are not provided by the API:
 

--- a/README.rst
+++ b/README.rst
@@ -74,6 +74,10 @@ The following attributes are currently supported:
     - map_this_home_link
     - latitude
     - latitude
+    - street
+    - city
+    - state
+    - zipcode
     - coordinates (as GEOS point)
     - tax_year
     - tax_value
@@ -91,6 +95,7 @@ The following attributes are currently supported:
     - zestimate_valuation_range_high
     - zestimate_valuationRange_low
     - zestimate_percentile
+    - price
 
 
 Usage of the GetUpdatedPropertyDetails API
@@ -114,6 +119,10 @@ The following attributes are currently supported:
     - photo_gallery
     - latitude
     - latitude
+    - street
+    - city
+    - state
+    - zipcode
     - coordinates (as GEOS point)
     - year_built
     - property_size
@@ -134,6 +143,7 @@ The following attributes are currently supported:
     - home_description
     - neighborhood
     - school_district
+    - price
 
 The following attributes are not provided by the API:
 

--- a/pyzillow/pyzillow.py
+++ b/pyzillow/pyzillow.py
@@ -141,6 +141,10 @@ class GetDeepSearchResults(ZillowResults):
         'home_detail_link': 'result/links/homedetails',
         'graph_data_link': 'result/links/graphsanddata',
         'map_this_home_link': 'result/links/mapthishome',
+        'street': 'result/address/street',
+        'city': 'result/address/city',
+        'state': 'result/address/state',
+        'zipcode': 'result/address/zipcode',
         'latitude': 'result/address/latitude',
         'longitude': 'result/address/longitude',
         'tax_year': 'result/taxAssessmentYear',
@@ -159,6 +163,7 @@ class GetDeepSearchResults(ZillowResults):
         'result/zestimate/valuationRange/high',
         'zestimate_valuationRange_low': 'result/zestimate/valuationRange/low',
         'zestimate_percentile': 'result/zestimate/percentile',
+        'price': 'result/price',
     }
 
     def __init__(self, data, *args, **kwargs):
@@ -185,6 +190,10 @@ class GetUpdatedPropertyDetails(ZillowResults):
         'map_this_home_link': '',
         'latitude': 'address/latitude',
         'longitude': 'address/longitude',
+        'street': 'result/address/street',
+        'city': 'result/address/city',
+        'state': 'result/address/state',
+        'zipcode': 'result/address/zipcode',
         'tax_year': '',
         'tax_value': '',
         'year_built': 'editedFacts/yearBuilt',
@@ -194,6 +203,7 @@ class GetUpdatedPropertyDetails(ZillowResults):
         'bedrooms': 'editedFacts/bedrooms',
         'last_sold_date': '',
         'last_sold_price': '',
+        'price': 'result/price',
         # new attributes in GetUpdatedPropertyDetails
         'photo_gallery': 'links/photoGallery',
         'home_info': 'links/homeInfo',


### PR DESCRIPTION
> ============================= test session starts ==============================
> platform linux2 -- Python 2.7.12, pytest-2.8.7, py-1.4.31, pluggy-0.3.1
> rootdir: /home/may/pyzillow, inifile:
> collected 10 items
> 
> test/test_pyzillow.py ....FF....
> 
> =================================== FAILURES ===================================
> _______________ TestPyzillow.test_zillow_error_no_property_match _______________
> 
> self = <test_pyzillow.TestPyzillow object at 0x7ffbb84f45d0>
> 
>     def test_zillow_error_no_property_match(self):
>         # This test checks the correct error message if no property is found.
>         # Expected error code: 508
>         # Address and zip code of an exisiting property, but not listed
>         address = '599 Pennsylvania Avenue Northwest, Washington, DC'
>         zipcode = '20001'
>         zillow_data = ZillowWrapper(self.ZILLOW_API_KEY)
>         raises(
>             ZillowError,
>             zillow_data.get_deep_search_results,
>             address=address,
> >           zipcode=zipcode)
> E       Failed: DID NOT RAISE
> 
> test/test_pyzillow.py:75: Failed
> ______________ TestPyzillow.test_zillow_error_match_zipcode_city _______________
> 
> self = <test_pyzillow.TestPyzillow object at 0x7ffbb84f4390>
> 
>     def test_zillow_error_match_zipcode_city(self):
>         # This test checks the correct error message if no zipcode is provided.
>         # Expected error code: 503
>         mismatch_zipcode = '97204'  # Portland, OR
>         zillow_data = ZillowWrapper(self.ZILLOW_API_KEY)
>         raises(
>             ZillowError,
>             zillow_data.get_deep_search_results,
>             address=self.address,
> >           zipcode=mismatch_zipcode)
> E       Failed: DID NOT RAISE
> 
> test/test_pyzillow.py:86: Failed
> ====================== 2 failed, 8 passed in 1.64 seconds ======================

Pretty sure these failures are irrelevant to the feature I added, which expands the attribute mapping to include address and price information from both Zillow APIs, used internally at [simpleshowing.com](simpleshowing.com) 